### PR TITLE
Moved useColor var closer to top of the file as it was referenced bef…

### DIFF
--- a/unit-test.sh
+++ b/unit-test.sh
@@ -30,6 +30,9 @@ shell return values are the opposite
 
 COMMENT
 
+# set useColor=0 should you want a log file without the escape codes
+useColor=${useColor:-1}
+
 if [[ $debug -eq 0 ]]; then
 	internalDebug=1
 else
@@ -92,9 +95,6 @@ isJQEnabled () {
 # enable for timestamped log files
 useTimeStamps=${useTimeStamps:-0}
 timeStamp=$(date +%Y-%m-%d_%H-%M-%S)
-
-# set useColor=0 should you want a log file without the escape codes
-useColor=${useColor:-1}
 
 printError () {
 	declare msg="$@"
@@ -209,7 +209,14 @@ run () {
 	echo "CMD: $cmd"
 	if $(isExeEnabled); then
 		#echo "CMD is Enabled"
-		$cmd
+
+		# eval "$cmd" is used as some commands take this form
+		# set_some_var=1 ./run-my-test.sh.
+		# simulated on the command line:
+		# "x=1 ls" - does not work
+		# eval "x=1 ls" - this does work
+
+		eval "$cmd"
 	else
 		echo "CMD is Disabled"
 	fi


### PR DESCRIPTION
…ore the definition if debug=1

Changed execution of $cmd to eval "$cmd" as commands that set a var on the CL before the script in the JSON file would not exe properly.

ie. RUNTIME_FATAL_WARNINGS=1 ./runcheck.sh ...

That would exit with command not found

simulated on the command line:
"x=1 ls" - does not work
eval "x=1 ls" - this does work