### PR TITLE
Accept string retval

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,38 +30,86 @@ Python is used as by default in includes JSON processing code.
 
 Currently this works with Python 2 only, Python 3 will cause an error.
 
-There are 3 values expected for each test, any notes, the cmd itself, and the expected return code
+There are 4 values expected for each test, any notes, the cmd itself, the type of the returned value and the expected return code
+
+There are two types of possible return values
+
+- integer
+- string
+
+If string it may be multiple workds, and *MUST* be the last line output by the script under test
 
 Following is the configuration file included here, unit-test.json
 
 ```json
 {
-   "comments" : "This is the configuration file for unit-test.sh",
-   "version" : 1.0,
-   "tests" : [
-      {
-         "notes" : "normal successful execution",
-         "cmd" : "./script-under-test.sh this is a test",
-         "result" : 0
-      },
-      {
-         "notes" : "execution with Warning ",
-         "cmd" : "./script-under-test.sh 1 this test exits with a warning",
-         "result" : 1
-      },
-      {
-         "notes" : "execution with Error ",
-         "cmd" : "test-cmd-3",
-         "cmd" : "./script-under-test.sh 2 this test exits with an error",
-         "result" : 2
-      },
-      {
-         "notes" : "This script does not exist",
-         "cmd" : "no-script-exists.sh",
-         "result" : 0
-      }
-   ]
+	"comments" : "This is the configuration file for unit-test.sh",
+	"version" : 1.0,
+	"tests" : [
+		{
+			"notes" : "normal successful execution",
+			"cmd" : "./script-under-test.sh this is a test",
+			"result-type" : "integer",
+			"result" : 0
+		},
+		{
+			"notes" : "execution with Warning ",
+			"cmd" : "./script-under-test.sh 1 this test exits with a warning",
+			"result-type" : "integer",
+			"result" : 1
+		},
+		{
+			"notes" : "execution with Error ",
+			"cmd" : "./script-under-test.sh 2 this test exits with an error",
+			"result-type" : "integer",
+			"result" : 2
+		},
+		{
+			"notes" : "This test should FAIL - This script name has a typo",
+			"cmd" : "./script-under-te5t.sh 2 this test exits with an error",
+			"result-type" : "integer",
+			"result" : 2
+		},
+		{
+			"notes" : "string return type - successful execution",
+			"cmd" : "./script-under-test-string.sh this is a test",
+			"result-type" : "string",
+			"result" : "OK"
+		},
+		{
+			"notes" : "string return type - Two Words returned - successful execution",
+			"cmd" : "./script-under-test-string.sh Two Words this is a test",
+			"result-type" : "string",
+			"result" : "Two Words"
+		},
+		{
+			"notes" : "string return type - successful execution of failure with warning",
+			"cmd" : "./script-under-test-string.sh Warning",
+			"result-type" : "string",
+			"result" : "Warning"
+		},
+		{
+			"notes" : "string return type - successful execution of failure with error",
+			"cmd" : "./script-under-test-string.sh Error",
+			"result-type" : "string",
+			"result" : "Error"
+		},
+		{
+			"notes" : "This test should FAIL - string return type - failed execution - expecting Error - gets OK",
+			"cmd" : "./script-under-test-string.sh OK",
+			"result-type" : "string",
+			"result" : "Error"
+		},
+		{
+			"notes" : "this test should FAIL - string return type - failed execution - expecting OK - gets Warning",
+			"cmd" : "./script-under-test-string.sh Warning",
+			"result-type" : "string",
+			"result" : "OK"
+		}
+	]
 }
+
+
 ```
 
 The validity of the file can be tested with the test-json.sh script

--- a/README.md
+++ b/README.md
@@ -114,33 +114,6 @@ Following is the configuration file included here, unit-test.json
 }
 ```
 
-The validity of the file can be tested with the test-json.sh script
-
-```bash
->  ./test-json.sh unit-test.json
-version: 1.0
-```
-
-If the script is not valid JSON there will be error output:
-
-```bash
-
->  ./test-json.sh unit-test.json
-version:
-Traceback (most recent call last):
-  File "<string>", line 1, in <module>
-  File "/usr/lib/python2.7/json/__init__.py", line 291, in load
-    **kw)
-  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
-    return _default_decoder.decode(s)
-  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
-    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
-  File "/usr/lib/python2.7/json/decoder.py", line 380, in raw_decode
-    obj, end = self.scan_once(s, idx)
-ValueError: Expecting property name: line 3 column 2 (char 4)
-
-```
-
 ## unit-test.sh
 
 Currently the name of the JSON file to be used is hard coded in the top of the script _unit-test.sh_.
@@ -183,6 +156,47 @@ Environment variables
 The timestamped logs are useful for comparing runs.
 
 Setting useColor=0 is useful when you need a logfile that does not have color escape codes in it.
+
+## convert-json.sh
+
+usage: convert-json.sh my-unit-tests.json
+
+If you have any JSON files that were created for use with the previous iteration of _unit-test.sh_, the _convert-json.sh_ script will add the "result-type" lines for you.
+
+Running the script twice on the same script will have no effect as the new line will be detected.
+
+## test-json.sh
+
+usage: test-json.sh
+
+The _test-json.sh_ script can be used to validate a JSON file.
+
+The script returns 0 for success, 1 for failure.
+
+
+```bash
+$ ./test-json.sh test.json
+version: 0.1
+$ $?
+0
+
+$  ./test-json.sh error.json
+version:
+Traceback (most recent call last):
+  File "<string>", line 1, in <module>
+  File "/usr/lib/python2.7/json/__init__.py", line 291, in load
+    **kw)
+  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
+    return _default_decoder.decode(s)
+  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
+    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
+    raise ValueError("No JSON object could be decoded")
+ValueError: No JSON object could be decoded
+
+$ echo $?
+1
+```
 
 # Dependencies
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ There are two types of possible return values
 - integer
 - string
 
-If string it may be multiple workds, and *MUST* be the last line output by the script under test
+If 'integer' the value is taken from $? as the ```exit N``` that indicates if the script execution succeeded or not.
+
+The traditional value for this is 0 (zero) for success, and different positive integers for failures, though it is not necessary to use 0 for success.
+
+If 'string' it may be multiple words, and the value used to determine success/failure *MUST* be the last line output by the script under test
 
 Following is the configuration file included here, unit-test.json
 
@@ -108,8 +112,6 @@ Following is the configuration file included here, unit-test.json
 		}
 	]
 }
-
-
 ```
 
 The validity of the file can be tested with the test-json.sh script

--- a/convert-json.sh
+++ b/convert-json.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+: << 'COMMENT'
+
+A simple script to add the 'return-type' line to existing JSON.
+
+COMMENT
+
+
+jsonToConvert=$1
+
+[[ -z $jsonToConvert ]] && {
+	echo
+	echo Please provide the JSON file to convert
+	echo
+	exit 1
+}
+
+# validate the incoming JSON
+
+./test-json.sh $jsonToConvert >/dev/null 2>&1
+
+if [[ $? -ne 0 ]]; then
+	echo
+	echo The file $jsonToConvert does not contain valid JSON
+	echo
+	exit 2
+fi
+
+# check if already converted
+
+if $(grep -q "result-type" $jsonToConvert); then
+	echo
+	echo "The file $jsonToConvert already has the 'result-type' data"
+	echo 
+	exit 3
+fi
+
+tmpJSONFile=/tmp/$$.json
+
+while IFS= read line
+do
+	# capture the same spacing
+	[[ $line =~ ([[:space:]]+) ]]
+	space=${BASH_REMATCH[1]}
+	#echo "SPACE: |$space|"
+	if [[ $line =~ '"result" :' ]]; then
+		echo "${space}"'"result-type" : "integer",'
+	fi
+	echo "$line"
+done < $jsonToConvert > $tmpJSONFile
+
+# validate the new JSON file
+
+./test-json.sh $tmpJSONFile >/dev/null 2>&1
+
+if [[ $? -ne 0 ]]; then
+	echo
+	echo Something has gone wrong 
+	echo The tmp file $tmpJSONFile does not contain valid JSON
+	echo Aborting...
+	echo
+	exit 4
+fi
+
+mv $jsonToConvert ${jsonToConvert}.orig
+mv $tmpJSONFile $jsonToConvert 
+
+rm -f $tmpJSONFile
+
+

--- a/convert-test.json
+++ b/convert-test.json
@@ -1,0 +1,27 @@
+
+
+{
+	"version" : 0.1,
+	"tests" : [
+		{
+			"notes" : "this is test notes 1",
+			"cmd" : "test-cmd-1",
+			"result-type" : "integer",
+			"result" : 0
+		},
+		{
+			"notes" : "this is test notes 2",
+			"cmd" : "test-cmd-2",
+			"result-type" : "integer",
+			"result" : 0
+		},
+		{
+			"notes" : "this is test notes 3",
+			"cmd" : "test-cmd-3",
+			"result-type" : "integer",
+			"result" : 1
+		}
+	]
+}
+
+

--- a/script-under-test-string.sh
+++ b/script-under-test-string.sh
@@ -25,7 +25,7 @@ declare -a argArray=($args)
 	exit 2
 }
 
-echo "OK"
+echo 'OK'
 
 exit 0
 

--- a/script-under-test-string.sh
+++ b/script-under-test-string.sh
@@ -13,6 +13,10 @@ declare args="$@"
 
 declare -a argArray=($args)
 
+# display output to verify unit-test.sh gets only the last line as the return value
+
+echo "Arguments: $args"
+
 #echo "Arg 0: ${argArray[0]}"
 
 [[ ${argArray[0]} == 'Warning' ]] && { 
@@ -23,6 +27,11 @@ declare -a argArray=($args)
 [[ ${argArray[0]} == 'Error' ]] && { 
 	echo 'Error'
 	exit 2
+}
+
+[[ ${argArray[0]} == 'Two' && ${argArray[1]} == 'Words' ]] && { 
+	echo 'Two Words'
+	exit 0
 }
 
 echo 'OK'

--- a/script-under-test-string.sh
+++ b/script-under-test-string.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+
+: << 'COMMENTS'
+
+If the first argument is 1 or 2, print warning or error message and exit appropriately
+
+Otherwise print the arguments and exit 0
+
+COMMENTS
+
+declare args="$@"
+
+declare -a argArray=($args)
+
+#echo "Arg 0: ${argArray[0]}"
+
+[[ ${argArray[0]} == 'Warning' ]] && { 
+	echo 'Warning'
+	exit 1
+}
+
+[[ ${argArray[0]} == 'Error' ]] && { 
+	echo 'Error'
+	exit 2
+}
+
+echo "OK"
+
+exit 0
+
+

--- a/test.json
+++ b/test.json
@@ -6,16 +6,19 @@
 		{
 			"notes" : "this is test notes 1",
 			"cmd" : "test-cmd-1",
+			"result-type" : "integer",
 			"result" : 0
 		},
 		{
 			"notes" : "this is test notes 2",
 			"cmd" : "test-cmd-2",
+			"result-type" : "integer",
 			"result" : 0
 		},
 		{
 			"notes" : "this is test notes 3",
 			"cmd" : "test-cmd-3",
+			"result-type" : "integer",
 			"result" : 1
 		}
 	]

--- a/unit-test.json
+++ b/unit-test.json
@@ -34,6 +34,12 @@
 			"result" : "OK"
 		},
 		{
+			"notes" : "string return type - Two Words returned - successful execution",
+			"cmd" : "./script-under-test-string.sh Two Words this is a test",
+			"result-type" : "string",
+			"result" : "Two Words"
+		},
+		{
 			"notes" : "string return type - successful execution of failure with warning",
 			"cmd" : "./script-under-test-string.sh Warning",
 			"result-type" : "string",

--- a/unit-test.json
+++ b/unit-test.json
@@ -22,7 +22,7 @@
 			"result" : 2
 		},
 		{
-			"notes" : "This script name has a typo",
+			"notes" : "This test should FAIL - This script name has a typo",
 			"cmd" : "./script-under-te5t.sh 2 this test exits with an error",
 			"result-type" : "integer",
 			"result" : 2
@@ -46,13 +46,13 @@
 			"result" : "Error"
 		},
 		{
-			"notes" : "string return type - failed execution - expecting Error - gets OK",
+			"notes" : "This test should FAIL - string return type - failed execution - expecting Error - gets OK",
 			"cmd" : "./script-under-test-string.sh OK",
 			"result-type" : "string",
 			"result" : "Error"
 		},
 		{
-			"notes" : "string return type - failed execution - expecting OK - gets Warning",
+			"notes" : "this test should FAIL - string return type - failed execution - expecting OK - gets Warning",
 			"cmd" : "./script-under-test-string.sh Warning",
 			"result-type" : "string",
 			"result" : "OK"

--- a/unit-test.json
+++ b/unit-test.json
@@ -6,22 +6,56 @@
 		{
 			"notes" : "normal successful execution",
 			"cmd" : "./script-under-test.sh this is a test",
+			"result-type" : "integer",
 			"result" : 0
 		},
 		{
 			"notes" : "execution with Warning ",
 			"cmd" : "./script-under-test.sh 1 this test exits with a warning",
+			"result-type" : "integer",
 			"result" : 1
 		},
 		{
 			"notes" : "execution with Error ",
 			"cmd" : "./script-under-test.sh 2 this test exits with an error",
+			"result-type" : "integer",
 			"result" : 2
 		},
 		{
 			"notes" : "This script name has a typo",
 			"cmd" : "./script-under-te5t.sh 2 this test exits with an error",
+			"result-type" : "integer",
 			"result" : 2
+		},
+		{
+			"notes" : "string return type - successful execution",
+			"cmd" : "./script-under-test-string.sh this is a test",
+			"result-type" : "string",
+			"result" : "OK"
+		},
+		{
+			"notes" : "string return type - successful execution of failure with warning",
+			"cmd" : "./script-under-test-string.sh Warning",
+			"result-type" : "string",
+			"result" : "Warning"
+		},
+		{
+			"notes" : "string return type - successful execution of failure with error",
+			"cmd" : "./script-under-test-string.sh Error",
+			"result-type" : "string",
+			"result" : "Error"
+		},
+		{
+			"notes" : "string return type - failed execution - expecting Error - gets OK",
+			"cmd" : "./script-under-test-string.sh OK",
+			"result-type" : "string",
+			"result" : "Error"
+		},
+		{
+			"notes" : "string return type - failed execution - expecting OK - gets Warning",
+			"cmd" : "./script-under-test-string.sh Warning",
+			"result-type" : "string",
+			"result" : "OK"
 		}
 	]
 }

--- a/unit-test.sh
+++ b/unit-test.sh
@@ -144,14 +144,14 @@ setDebug () {
 	internalDebug=$1
 }
 
-redirectSTDIN () {
+redirectSTDOUT () {
 	# save old STDOUT
 	exec {channels[$stdoutSaveChannel]}>&"$STDOUT"
 	# redirect STDOUT to STDERR
 	exec {channels[$STDIN]}>&"$STDERR"
 }
 
-restoreSTDIN () {
+restoreSTDOUT () {
 	exec {channels[$STDIN]}>&"${channels[$stdoutSaveChannel]}"
 	exec {channels[$stdoutSaveChannel]}>&-
 
@@ -163,9 +163,9 @@ printDebug () {
 	if $(isDebugEnabled); then
 		if [[ $useColor -ne 0 ]]; then
 			# redirect this call to STDERR as all debug statements to go to STDERR
-			redirectSTDIN
+			redirectSTDOUT
 			colorPrint fg=lightYellow bg=blue msg="$msg"
-			restoreSTDIN
+			restoreSTDOUT
 		else
 			echo 1>&2 "$msg"
 		fi
@@ -249,9 +249,9 @@ printError () {
 	declare msg="$@"
 	if [[ $useColor -ne 0 ]]; then
 
-		redirectSTDIN
+		redirectSTDOUT
 		colorPrint fg=red bg=lightGray msg="$msg"
-		restoreSTDIN
+		restoreSTDOUT
 	else
 		echo 1>&2 "$msg"
 	fi
@@ -260,9 +260,9 @@ printError () {
 printErrorRpt () {
 	declare msg="$@"
 	if [[ $useColor -ne 0 ]]; then
-		redirectSTDIN
+		redirectSTDOUT
 		colorPrint fg=black bg=yellow msg="$msg"
-		restoreSTDIN
+		restoreSTDOUT
 	else
 		echo 1>&2 "$msg"
 	fi
@@ -271,9 +271,9 @@ printErrorRpt () {
 printTestError () {
 	declare msg="$@"
 	if [[ $useColor -ne 0 ]]; then
-		redirectSTDIN
+		redirectSTDOUT
 		colorPrint fg=white bg=red msg="$msg"
-		restoreSTDIN
+		restoreSTDOUT
 	else
 		echo 1>&2 "$msg"
 	fi
@@ -282,9 +282,9 @@ printTestError () {
 printOK () {
 	declare msg="$@"
 	if [[ $useColor -ne 0 ]]; then
-		redirectSTDIN
+		redirectSTDOUT
 		colorPrint fg=black bg=lightGreen msg="$msg"
-		restoreSTDIN
+		restoreSTDOUT
 	else
 		echo 1>&2 "$msg"
 	fi
@@ -301,9 +301,9 @@ printMsg () {
 		# output
 		# for some reason using the functions to do the redirect break the code in run() when it calls printMsg()
 		# do not yet know why - not using printMsg there for now
-		redirectSTDIN
+		redirectSTDOUT
 		colorPrint fg=black bg=cyan msg="$msg"
-		restoreSTDIN
+		restoreSTDOUT
 		# restore STDOUT and close 7
 		#exec 1>&7 7>&-
 	else
@@ -455,7 +455,7 @@ run () {
 		# eval "x=1 ls" - this does work
 
 		# do not use printMsg in this code
-		# the calls to redirectSTDIN and restoreSTDIN that are in printMsg() cause this to break
+		# the calls to redirectSTDOUT and restoreSTDOUT that are in printMsg() cause this to break
 		#printMsg "arg type: $returnType"
 		echo 1>&2 "arg type: $returnType"
 


### PR DESCRIPTION
Previously the return value from the script under test was simply the exit value.

Now a string value can also be used.

Making this work required quite a bit more effort than anticipated.

Works now.
